### PR TITLE
Fix f-string quotations and allow specifying font family

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ lc.bar_chart_race(
     startDate           = None,     # Optional start date for plot, format ISO 8601 (YYYY-MM-DD)
     endDate             = None,     # Optional end date for plot, format ISO 8601 (YYYY-MM-DD)
     length              = 10,       # Length of the resulting video in seconds
-    f_period            = 15,       # Number of dates to plot per second
+    f_periods           = 15,       # Number of dates to plot per second
     format              = "gif",    # Format to save, gif, mp4,...
     skip_empty_dates    = False,    # Option to skip dates with no scrobbles           
     **{"steps_per_period" : 4,      # Number of frames per period

--- a/src/lastcharts/main.py
+++ b/src/lastcharts/main.py
@@ -498,7 +498,7 @@ class LastCharts:
         Args:
             df: Dataframe used for plotting
         """
-        return f"{df["datetime"].iloc[-1].strftime("%Y-%m-%d")} - {df["datetime"].iloc[0].strftime("%Y-%m-%d")}"
+        return f"{df['datetime'].iloc[-1].strftime('%Y-%m-%d')} - {df['datetime'].iloc[0].strftime('%Y-%m-%d')}"
 
 
 def main():

--- a/src/lastcharts/main.py
+++ b/src/lastcharts/main.py
@@ -17,6 +17,7 @@ from thefuzz import process
 from . import utils
 from .lastfm import LastFM
 
+DEFAULT_FONT = "Comfortaa"
 
 class LastCharts:
     """Python class to plot charts from LastFM data"""
@@ -31,10 +32,10 @@ class LastCharts:
     _FONT_SIZE_LEGEND = 18
     _FIG_SIZE_STACKEDBARS = (15, 7)
     _FIG_SIZE_BCR = (6, 3.5)
-    _FONT = "Comfortaa"
+    _FONT = DEFAULT_FONT
     _CMAP = "Set2"
 
-    def __init__(self, API_KEY, USER_AGENT):
+    def __init__(self, API_KEY, USER_AGENT, font = DEFAULT_FONT):
         """Instiantiate LastCharts class
 
         Args:
@@ -53,11 +54,12 @@ class LastCharts:
         self.df = None
 
         # Configure matplotlib for stacked bar plot
+        self._FONT = font
         plt.rcParams["figure.figsize"] = self._FIG_SIZE_STACKEDBARS
         if self._FONT in font_manager.fontManager.get_font_names():
             plt.rcParams["font.family"] = self._FONT
         else:
-            print(f"Font {self._FONT} not installed, using default font.")
+            print(f"Font {self._FONT} not installed, using fallback font.")
         plt.rcParams["axes.prop_cycle"] = cycler(color=plt.get_cmap(self._CMAP).colors)
 
     def load_scrobbles(self, user: str = None):


### PR DESCRIPTION
Awesome project! It worked well except these some small issues I've discovered and fixed. 

- ill-formatted f-string quotations on `main.py:501`
- added support for specifying alternative font for Unicode characters
  ```py
  lc = lastcharts.LastCharts(API_KEY, USERNAME, font = 'Noto Sans CJK JP')
  ```
- a small typo in README

I hope you find this PR useful. Thank you!